### PR TITLE
Fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ See an example app at https://github.com/Dania02525/widget_saas
 
 - Add this to your mix.exs deps:
 ```elixir
-{:apartmentex, github: "/Dania02525/apartmentex"}
+{:apartmentex, github: "Dania02525/apartmentex"}
 ```
 - Run mix deps.get && mix deps.compile
 


### PR DESCRIPTION
Fixes error during `mix deps.get` (notice the double slash in URL):

```
** (Mix) Command "git clone --no-checkout --progress "https://github.com//Dania02525/apartmentex.git" "/my-repo/deps/apartmentex"" failed
```
