### PR TITLE
Fix compilation with newest Ecto 1.1.x

### DIFF
--- a/lib/adapters/postgres/connection.ex
+++ b/lib/adapters/postgres/connection.ex
@@ -1,4 +1,4 @@
-if Code.ensure_loaded?(Postgrex.Connection) do
+if Code.ensure_loaded?(Postgrex) do
 
   defmodule Apartmentex.Adapters.Postgres.Connection do
     @moduledoc false
@@ -19,7 +19,7 @@ if Code.ensure_loaded?(Postgrex.Connection) do
         |> Keyword.update(:extensions, extensions, &(&1 ++ extensions))
         |> Keyword.update(:port, @default_port, &normalize_port/1)
 
-      Postgrex.Connection.start_link(opts)
+      Postgrex.start_link(opts)
     end
 
     def query(conn, sql, params, opts) do
@@ -28,7 +28,7 @@ if Code.ensure_loaded?(Postgrex.Connection) do
         value -> value
       end
 
-      case Postgrex.Connection.query(conn, sql, params, opts) do
+      case Postgrex.query(conn, sql, params, opts) do
         {:ok, res}        -> {:ok, Map.from_struct(res)}
         {:error, _} = err -> err
       end

--- a/lib/adapters/postgres/datetime.ex
+++ b/lib/adapters/postgres/datetime.ex
@@ -1,4 +1,4 @@
-if Code.ensure_loaded?(Postgrex.Connection) do
+if Code.ensure_loaded?(Postgrex) do
 
   defmodule Apartmentex.Adapters.Postgres.DateTime do
     @moduledoc false

--- a/lib/apartmentex.ex
+++ b/lib/apartmentex.ex
@@ -96,7 +96,7 @@ defmodule Apartmentex do
   def insert(repo, %Changeset{} = changeset, tenant, opts) when is_list(opts) do
     changeset = MHelpers.update_changeset(changeset, :changeset, :insert, repo, opts)
 
-    new_changeset = %{changeset | model: Ecto.Model.put_meta(changeset.model,  prefix: build_prefix(tenant))}
+    new_changeset = %{changeset | model: Ecto.put_meta(changeset.model,  prefix: build_prefix(tenant))}
     MHelpers.do_insert(repo, repo.__adapter__, new_changeset, opts)
   end
 
@@ -106,7 +106,7 @@ defmodule Apartmentex do
       |> Ecto.Changeset.change()
       |> MHelpers.update_changeset(:model, :insert, repo, opts)
 
-    new_changeset = %{changeset | model: Ecto.Model.put_meta(changeset.model,  prefix: build_prefix(tenant))}
+    new_changeset = %{changeset | model: Ecto.put_meta(changeset.model,  prefix: build_prefix(tenant))}
     MHelpers.do_insert(repo, repo.__adapter__, new_changeset, opts)
   end
 
@@ -132,7 +132,7 @@ defmodule Apartmentex do
   def update(repo, %Changeset{} = changeset, tenant, opts) when is_list(opts) do
     changeset = MHelpers.update_changeset(changeset, :changeset, :update, repo, opts)
 
-    new_changeset = %{changeset | model: Ecto.Model.put_meta(changeset.model,  prefix: build_prefix(tenant))}
+    new_changeset = %{changeset | model: Ecto.put_meta(changeset.model,  prefix: build_prefix(tenant))}
     MHelpers.do_update(repo, repo.__adapter__, new_changeset, opts)
   end
 
@@ -149,7 +149,7 @@ defmodule Apartmentex do
       |> Map.put(:changes, changes)
       |> MHelpers.update_changeset(:model, :update, repo, opts)
 
-    new_changeset = %{changeset | model: Ecto.Model.put_meta(changeset.model,  prefix: build_prefix(tenant))}
+    new_changeset = %{changeset | model: Ecto.put_meta(changeset.model,  prefix: build_prefix(tenant))}
     MHelpers.do_update(repo, repo.__adapter__, new_changeset, opts)
   end
 
@@ -194,7 +194,7 @@ defmodule Apartmentex do
   def delete(repo, %Changeset{} = changeset, tenant, opts) when is_list(opts) do
     changeset = MHelpers.update_changeset(changeset, :changeset, :delete, repo, opts)
 
-    new_changeset = %{changeset | model: Ecto.Model.put_meta(changeset.model,  prefix: build_prefix(tenant))}
+    new_changeset = %{changeset | model: Ecto.put_meta(changeset.model,  prefix: build_prefix(tenant))}
     MHelpers.do_delete(repo, repo.__adapter__, new_changeset, opts)
   end
 
@@ -204,7 +204,7 @@ defmodule Apartmentex do
       |> Ecto.Changeset.change()
       |> MHelpers.update_changeset(:model, :delete, repo, opts)
 
-    new_changeset = %{changeset | model: Ecto.Model.put_meta(changeset.model,  prefix: build_prefix(tenant))}
+    new_changeset = %{changeset | model: Ecto.put_meta(changeset.model,  prefix: build_prefix(tenant))}
     MHelpers.do_delete(repo, repo.__adapter__, new_changeset, opts)
   end
 

--- a/lib/migration/schema_migration.ex
+++ b/lib/migration/schema_migration.ex
@@ -2,6 +2,7 @@ defmodule Apartmentex.Migration.SchemaMigration do
   # Define a schema that works with the schema_migrations table
   @moduledoc false
   use Ecto.Model
+  import Ecto, only: [put_meta: 2]
   import Ecto.Query, only: [from: 2]
 
   @primary_key false

--- a/mix.exs
+++ b/mix.exs
@@ -28,6 +28,6 @@ defmodule Apartmentex.Mixfile do
   # Type "mix help deps" for more examples and options
   defp deps do
     [{:postgrex, ">= 0.0.0"},
-    {:ecto, "~> 1.0"}]
+    {:ecto, "~> 1.1.8"}]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,6 @@
-%{"decimal": {:hex, :decimal, "1.1.0"},
-  "ecto": {:hex, :ecto, "1.0.4"},
-  "poolboy": {:hex, :poolboy, "1.5.1"},
-  "postgrex": {:hex, :postgrex, "0.9.1"}}
+%{"connection": {:hex, :connection, "1.0.3", "3145f7416be3df248a4935f24e3221dc467c1e3a158d62015b35bd54da365786", [:mix], []},
+  "db_connection": {:hex, :db_connection, "1.0.0-rc.3", "d9ceb670fe300271140af46d357b669983cd16bc0d01206d7d3222dde56cf038", [:mix], [{:sbroker, "~> 1.0.0-beta.3", [hex: :sbroker, optional: true]}, {:poolboy, "~> 1.5", [hex: :poolboy, optional: true]}, {:connection, "~> 1.0.2", [hex: :connection, optional: false]}]},
+  "decimal": {:hex, :decimal, "1.1.2", "79a769d4657b2d537b51ef3c02d29ab7141d2b486b516c109642d453ee08e00c", [:mix], []},
+  "ecto": {:hex, :ecto, "1.1.8", "0f0348e678fa5a450c266d69816808f97fbd82ade32cf88d4b09bbe8f8c27545", [:mix], [{:sbroker, "~> 0.7", [hex: :sbroker, optional: true]}, {:postgrex, "~> 0.11.0", [hex: :postgrex, optional: true]}, {:poolboy, "~> 1.4", [hex: :poolboy, optional: false]}, {:poison, "~> 1.0 or ~> 2.0", [hex: :poison, optional: true]}, {:mariaex, "~> 0.5.0 or ~> 0.6.0", [hex: :mariaex, optional: true]}, {:decimal, "~> 1.0", [hex: :decimal, optional: false]}]},
+  "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], []},
+  "postgrex": {:hex, :postgrex, "0.11.2", "139755c1359d3c5c6d6e8b1ea72556d39e2746f61c6ddfb442813c91f53487e8", [:mix], [{:connection, "~> 1.0", [hex: :connection, optional: false]}, {:db_connection, "~> 1.0-rc", [hex: :db_connection, optional: false]}, {:decimal, "~> 1.0", [hex: :decimal, optional: false]}]}}


### PR DESCRIPTION
The `put_meta/2` function was moved from `Ecto.Model` to top-level `Ecto` module.

See https://github.com/elixir-ecto/ecto/commit/b33075098376b75008b24a115652c6c7cbd71feb
