### PR TITLE
Fix compiling against Ecto 1.1.x

### DIFF
--- a/lib/adapters/sql.ex
+++ b/lib/adapters/sql.ex
@@ -181,7 +181,7 @@ defmodule Apartmentex.Adapters.SQL do
   end
 
   defp query(repo, sql, params, outer_queue_time, mapper, opts) do
-    {pool_mod, pool, timeout} = repo.__pool__
+    {pool_mod, pool, timeout, _} = repo.__pool__
     opts    = Keyword.put_new(opts, :timeout, timeout)
     timeout = Keyword.fetch!(opts, :timeout)
     log?    = Keyword.get(opts, :log, true)

--- a/lib/apartmentex.ex
+++ b/lib/apartmentex.ex
@@ -96,7 +96,7 @@ defmodule Apartmentex do
   def insert(repo, %Changeset{} = changeset, tenant, opts) when is_list(opts) do
     changeset = MHelpers.update_changeset(changeset, :changeset, :insert, repo, opts)
 
-    new_changeset = %{changeset | model: Ecto.Model.put_meta(changeset.model,  prefix: build_prefix(tenant))}
+    new_changeset = %{changeset | model: Ecto.put_meta(changeset.model,  prefix: build_prefix(tenant))}
     MHelpers.do_insert(repo, repo.__adapter__, new_changeset, opts)
   end
 
@@ -106,7 +106,7 @@ defmodule Apartmentex do
       |> Ecto.Changeset.change()
       |> MHelpers.update_changeset(:model, :insert, repo, opts)
 
-    new_changeset = %{changeset | model: Ecto.Model.put_meta(changeset.model,  prefix: build_prefix(tenant))}
+    new_changeset = %{changeset | model: Ecto.put_meta(changeset.model,  prefix: build_prefix(tenant))}
     MHelpers.do_insert(repo, repo.__adapter__, new_changeset, opts)
   end
 
@@ -132,7 +132,7 @@ defmodule Apartmentex do
   def update(repo, %Changeset{} = changeset, tenant, opts) when is_list(opts) do
     changeset = MHelpers.update_changeset(changeset, :changeset, :update, repo, opts)
 
-    new_changeset = %{changeset | model: Ecto.Model.put_meta(changeset.model,  prefix: build_prefix(tenant))}
+    new_changeset = %{changeset | model: Ecto.put_meta(changeset.model,  prefix: build_prefix(tenant))}
     MHelpers.do_update(repo, repo.__adapter__, new_changeset, opts)
   end
 
@@ -149,7 +149,7 @@ defmodule Apartmentex do
       |> Map.put(:changes, changes)
       |> MHelpers.update_changeset(:model, :update, repo, opts)
 
-    new_changeset = %{changeset | model: Ecto.Model.put_meta(changeset.model,  prefix: build_prefix(tenant))}
+    new_changeset = %{changeset | model: Ecto.put_meta(changeset.model,  prefix: build_prefix(tenant))}
     MHelpers.do_update(repo, repo.__adapter__, new_changeset, opts)
   end
 
@@ -194,7 +194,7 @@ defmodule Apartmentex do
   def delete(repo, %Changeset{} = changeset, tenant, opts) when is_list(opts) do
     changeset = MHelpers.update_changeset(changeset, :changeset, :delete, repo, opts)
 
-    new_changeset = %{changeset | model: Ecto.Model.put_meta(changeset.model,  prefix: build_prefix(tenant))}
+    new_changeset = %{changeset | model: Ecto.put_meta(changeset.model,  prefix: build_prefix(tenant))}
     MHelpers.do_delete(repo, repo.__adapter__, new_changeset, opts)
   end
 
@@ -204,7 +204,7 @@ defmodule Apartmentex do
       |> Ecto.Changeset.change()
       |> MHelpers.update_changeset(:model, :delete, repo, opts)
 
-    new_changeset = %{changeset | model: Ecto.Model.put_meta(changeset.model,  prefix: build_prefix(tenant))}
+    new_changeset = %{changeset | model: Ecto.put_meta(changeset.model,  prefix: build_prefix(tenant))}
     MHelpers.do_delete(repo, repo.__adapter__, new_changeset, opts)
   end
 

--- a/lib/migration/schema_migration.ex
+++ b/lib/migration/schema_migration.ex
@@ -22,7 +22,7 @@ defmodule Apartmentex.Migration.SchemaMigration do
   end
 
   def up(repo, version, prefix) do
-    repo.insert! %__MODULE__{version: version} |> put_meta(prefix: prefix), @opts
+    repo.insert! %__MODULE__{version: version} |> Ecto.put_meta(prefix: prefix), @opts
   end
 
   def down(repo, version, prefix) do

--- a/mix.exs
+++ b/mix.exs
@@ -27,7 +27,7 @@ defmodule Apartmentex.Mixfile do
   #
   # Type "mix help deps" for more examples and options
   defp deps do
-    [{:postgrex, ">= 0.0.0"},
+    [{:postgrex, "< 0.11.0"},
     {:ecto, "~> 1.0"}]
   end
 end


### PR DESCRIPTION
This compiles with postgrex v0.10.0 and ecto 1.1.2

Since the library is not compatible with postgrex v0.11.0 at this point, this commit also locks the postgrex dependency to versions less than v0.11.0.

The `put_meta/2` function was moved from `Ecto.Model` to top-level `Ecto` module.

See https://github.com/elixir-ecto/ecto/commit/b33075098376b75008b24a115652c6c7cbd71feb
