### PR TITLE
CircleCI setup

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,11 @@
+dependencies:
+  pre:
+    - wget http://packages.erlang-solutions.com/erlang-solutions_1.0_all.deb && sudo dpkg -i erlang-solutions_1.0_all.deb
+    - sudo apt-get update
+    - sudo apt-get install elixir
+    - yes | mix deps.get
+    - mix local.rebar
+test:
+  override:
+    - MIX_ENV=prod mix compile --warnings-as-errors
+    - mix test

--- a/circle.yml
+++ b/circle.yml
@@ -7,5 +7,5 @@ dependencies:
     - mix local.rebar
 test:
   override:
-    - MIX_ENV=prod mix compile --warnings-as-errors
+    - MIX_ENV=prod mix compile
     - mix test


### PR DESCRIPTION
This PR includes configuration for https://circleci.com, which offers free CI services for open source projects. See this configuration successfully running tests on my fork: https://circleci.com/gh/iancanderson/apartmentex/4

This would help ensure that pull requests don't create regressions in the behavior, which will become even more important as the project is upgraded to work with newer dependencies of Ecto, etc.

To enable this, you'll have to log in to CircleCI and add this project to get it building and reporting statuses on new pull requests.
