### PR TITLE
Add integration tests

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -28,3 +28,7 @@ use Mix.Config
 # here (which is why it is important to import them last).
 #
 #     import_config "#{Mix.env}.exs"
+
+if Mix.env == :test do
+  import_config "test.exs"
+end

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,0 +1,9 @@
+use Mix.Config
+
+config :apartmentex, Apartmentex.TestPostgresRepo,
+  hostname: "localhost",
+  database: "apartmentex_test",
+  adapter: Ecto.Adapters.Postgres,
+  pool: Ecto.Adapters.SQL.Sandbox
+
+config :logger, level: :warn

--- a/mix.exs
+++ b/mix.exs
@@ -27,7 +27,7 @@ defmodule Apartmentex.Mixfile do
   #
   # Type "mix help deps" for more examples and options
   defp deps do
-    [{:postgrex, "< 0.11.0"},
-    {:ecto, "~> 1.0"}]
+    [{:postgrex, "~> 0.10.0"},
+    {:ecto, "~> 1.1.0"}]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,5 @@
-%{"decimal": {:hex, :decimal, "1.1.0"},
-  "ecto": {:hex, :ecto, "1.0.4"},
-  "poolboy": {:hex, :poolboy, "1.5.1"},
-  "postgrex": {:hex, :postgrex, "0.9.1"}}
+%{"connection": {:hex, :connection, "1.0.3", "3145f7416be3df248a4935f24e3221dc467c1e3a158d62015b35bd54da365786", [:mix], []},
+  "decimal": {:hex, :decimal, "1.1.2", "79a769d4657b2d537b51ef3c02d29ab7141d2b486b516c109642d453ee08e00c", [:mix], []},
+  "ecto": {:hex, :ecto, "1.1.2", "b18fc577b21dd11b8bcaef6ff06c16793583cd309d359eb22465c180e69bd5ba", [:mix], [{:sbroker, "~> 0.7", [hex: :sbroker, optional: true]}, {:postgrex, "~> 0.10.0", [hex: :postgrex, optional: true]}, {:poolboy, "~> 1.4", [hex: :poolboy, optional: false]}, {:poison, "~> 1.0", [hex: :poison, optional: true]}, {:mariaex, "~> 0.5.0", [hex: :mariaex, optional: true]}, {:decimal, "~> 1.0", [hex: :decimal, optional: false]}]},
+  "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], []},
+  "postgrex": {:hex, :postgrex, "0.10.0", "98cf581bbb921d696db261d1a9e1740252714dbea1f9224d3291d58f2d88ea82", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, optional: false]}, {:connection, "~> 1.0", [hex: :connection, optional: false]}]}}

--- a/priv/repo/tenant_migrations/20160711125401_test_create_tenant_notes.exs
+++ b/priv/repo/tenant_migrations/20160711125401_test_create_tenant_notes.exs
@@ -1,0 +1,9 @@
+defmodule Apartmentex.TestPostgresRepo.Migrations.CreateTenantUser do
+  use Apartmentex.Migration
+
+  def change do
+    create table(:notes) do
+      add :body, :string
+    end
+  end
+end

--- a/test/apartmentex_test.exs
+++ b/test/apartmentex_test.exs
@@ -1,0 +1,90 @@
+defmodule Apartmentex.ApartmentexTest do
+  use ExUnit.Case
+
+  alias Apartmentex.TestPostgresRepo
+
+  defmodule Note do
+    use Ecto.Schema
+    import Ecto.Changeset
+
+    schema "notes" do
+      field :body, :string
+    end
+
+    def changeset(model, params \\ :empty) do
+      model
+      |> cast(params, ~w(body), [])
+    end
+  end
+
+  setup do
+    Ecto.Adapters.SQL.restart_test_transaction(TestPostgresRepo)
+    :ok
+  end
+
+  test ".all/4 only returns the tenant's records" do
+    tenant_id = 2
+    other_tenant_id = 1
+
+    Apartmentex.new_tenant(TestPostgresRepo, tenant_id)
+    Apartmentex.new_tenant(TestPostgresRepo, other_tenant_id)
+
+    inserted_note = Apartmentex.insert!(TestPostgresRepo, %Note{body: "foo"}, tenant_id)
+    _other_note = Apartmentex.insert!(TestPostgresRepo, %Note{body: "bar"}, other_tenant_id)
+
+    fetched_notes = Apartmentex.all(TestPostgresRepo, Note, tenant_id)
+    fetched_note = List.first(fetched_notes)
+
+    assert length(fetched_notes) == 1
+    assert fetched_note.id == inserted_note.id
+    assert fetched_note.body == "foo"
+  end
+
+  test ".get!/5 returns a tenant's record by id" do
+    tenant_id = 2
+
+    Apartmentex.new_tenant(TestPostgresRepo, tenant_id)
+
+    inserted_note = Apartmentex.insert!(TestPostgresRepo, %Note{body: "foo"}, tenant_id)
+    fetched_note = Apartmentex.get!(TestPostgresRepo, Note, inserted_note.id, tenant_id)
+
+    assert fetched_note.id == inserted_note.id
+    assert fetched_note.body == "foo"
+  end
+
+  test ".get_by!/5 returns a tenant's record by conditions" do
+    tenant_id = 2
+
+    Apartmentex.new_tenant(TestPostgresRepo, tenant_id)
+
+    inserted_note = Apartmentex.insert!(TestPostgresRepo, %Note{body: "foo"}, tenant_id)
+    fetched_note = Apartmentex.get_by!(TestPostgresRepo, Note, %{body: "foo"}, tenant_id)
+
+    assert fetched_note.id == inserted_note.id
+    assert fetched_note.body == "foo"
+  end
+
+  test ".update!/4 updates a tenant's record" do
+    tenant_id = 2
+
+    Apartmentex.new_tenant(TestPostgresRepo, tenant_id)
+
+    inserted_note = Apartmentex.insert!(TestPostgresRepo, %Note{body: "foo"}, tenant_id)
+    changeset = Note.changeset(inserted_note, %{body: "bar"})
+    updated_note = Apartmentex.update!(TestPostgresRepo, changeset, tenant_id)
+
+    assert updated_note.id == inserted_note.id
+    assert updated_note.body == "bar"
+  end
+
+  test ".delete!/4 deletes a tenant's record by id" do
+    tenant_id = 2
+
+    Apartmentex.new_tenant(TestPostgresRepo, tenant_id)
+
+    inserted_note = Apartmentex.insert!(TestPostgresRepo, %Note{body: "foo"}, tenant_id)
+    Apartmentex.delete!(TestPostgresRepo, inserted_note, tenant_id)
+
+    refute Apartmentex.get(TestPostgresRepo, Note, inserted_note.id, tenant_id)
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,2 +1,14 @@
 Code.require_file "./test_repo.exs", __DIR__
+
+defmodule Apartmentex.TestPostgresRepo do
+  use Ecto.Repo, otp_app: :apartmentex, adapter: Ecto.Adapters.Postgres
+end
+
+Mix.Task.run "ecto.drop", ["quiet", "-r", "Apartmentex.TestPostgresRepo"]
+Mix.Task.run "ecto.create", ["quiet", "-r", "Apartmentex.TestPostgresRepo"]
+
+Apartmentex.TestPostgresRepo.start_link
+
 ExUnit.start()
+
+Ecto.Adapters.SQL.begin_test_transaction(Apartmentex.TestPostgresRepo)


### PR DESCRIPTION
It would be nice to merge https://github.com/Dania02525/apartmentex/pull/7 first and enable CircleCI first 😄 

This commit adds end-to-end integration tests, which:
1.) Creates a tenant (new schema in postgres DB)
2.) Inserts/updates/deletes/reads tenant data

These tests will be very useful when upgrading the library to support newer versions of ecto and postgrex.

This commit also locks Ecto to 1.1.x and postgrex to 0.10.x, which should have been done as part of https://github.com/Dania02525/apartmentex/pull/5

Without locking these, mix could resolve the libraries to versions which are not compatible with the code changes made as part of https://github.com/Dania02525/apartmentex/pull/5
