### PR TITLE
Build tenant migrations path more reliably

### DIFF
--- a/lib/apartmentex.ex
+++ b/lib/apartmentex.ex
@@ -2,10 +2,8 @@ defmodule Apartmentex do
   alias Ecto.Changeset
   import Apartmentex.PrefixBuilder
 
-  defdelegate [
-    drop_tenant(repo, tenant),
-    new_tenant(repo, tenant)
-  ], to: Apartmentex.TenantActions
+  defdelegate drop_tenant(repo, tenant), to: Apartmentex.TenantActions
+  defdelegate new_tenant(repo, tenant), to: Apartmentex.TenantActions
 
   def all(repo, queryable, tenant, opts \\ []) when is_list(opts) do
     queryable

--- a/lib/apartmentex.ex
+++ b/lib/apartmentex.ex
@@ -11,7 +11,12 @@ defmodule Apartmentex do
       Ecto.Adapters.Postgres -> Ecto.Adapters.SQL.query(repo, "CREATE SCHEMA #{prefix}", [])
       Ecto.Adapters.MySQL -> Ecto.Adapters.SQL.query(repo, "CREATE DATABASE #{prefix}", [])
     end
-    Ecto.Migrator.run(repo, @tenant_migration_folder, :up, [all: true, prefix: String.to_atom(prefix)])
+    Ecto.Migrator.run(repo, tenant_migration_folder(repo), :up, [all: true, prefix: String.to_atom(prefix)])
+  end
+
+  defp tenant_migration_folder(repo) do
+    Keyword.fetch!(repo.config(), :otp_app)
+    |> Application.app_dir(@tenant_migration_folder)
   end
 
   def drop_tenant(repo, tenant) do

--- a/lib/apartmentex/prefix_builder.ex
+++ b/lib/apartmentex/prefix_builder.ex
@@ -1,0 +1,15 @@
+defmodule Apartmentex.PrefixBuilder do
+  @schema_prefix Application.get_env(:apartmentex, :schema_prefix) || "tenant_"
+
+  def build_prefix(tenant) when is_integer(tenant) do
+    @schema_prefix <> Integer.to_string(tenant)
+  end
+
+  def build_prefix(tenant) when is_binary(tenant) do
+    @schema_prefix <> tenant
+  end
+
+  def build_prefix(tenant) do
+    @schema_prefix <> Integer.to_string(tenant.id)
+  end
+end

--- a/lib/apartmentex/tenant_actions.ex
+++ b/lib/apartmentex/tenant_actions.ex
@@ -1,0 +1,28 @@
+defmodule Apartmentex.TenantActions do
+  @tenant_migration_folder "priv/repo/tenant_migrations"
+  #warning: don't change this after you already have tenants
+
+  import Apartmentex.PrefixBuilder
+
+  def new_tenant(repo, tenant) do
+    prefix = build_prefix(tenant)
+    case repo.__adapter__ do
+      Ecto.Adapters.Postgres -> Ecto.Adapters.SQL.query(repo, "CREATE SCHEMA #{prefix}", [])
+      Ecto.Adapters.MySQL -> Ecto.Adapters.SQL.query(repo, "CREATE DATABASE #{prefix}", [])
+    end
+    Ecto.Migrator.run(repo, tenant_migration_folder(repo), :up, [all: true, prefix: String.to_atom(prefix)])
+  end
+
+  def drop_tenant(repo, tenant) do
+    prefix = build_prefix(tenant)
+    case repo.__adapter__ do
+      Ecto.Adapters.Postgres -> Ecto.Adapters.SQL.query(repo, "DROP SCHEMA #{prefix} CASCADE", [])
+      Ecto.Adapters.MySQL -> Ecto.Adapters.SQL.query(repo, "DROP DATABASE #{prefix}", [])
+    end
+  end
+
+  defp tenant_migration_folder(repo) do
+    Keyword.fetch!(repo.config(), :otp_app)
+    |> Application.app_dir(@tenant_migration_folder)
+  end
+end


### PR DESCRIPTION
I noticed an issue when trying to migrate data from the public schema
into the private tenant schemas when using a released version of the
phoenix app (built by exrm with `mix release`). The simple relative path
approach to finding the tenant migrations doesn't work within the
context of an exrm release. I looked into how Ecto deals with this
problem, and noticed it uses the `Application.app_dir` function to build
the path to the migrations, passing in the `:otp_app` that was
configured with the `Repo` module.

See
http://blog.plataformatec.com.br/2016/04/running-migration-in-an-exrm-release/
for more info about running deployment/release tasks exrm releases.

With this commit, tenant migrations are found, even within the context
of an exrm release command. i.e. if you have a `Release.Tasks` module
with a `migrate_tenants` function that calls `Apartmentex.new_tenant`,
then this command will now successfully find the tenant migrations
within the released app:

``` sh
rel/my_app/bin/my_app command Elixir.Release.Tasks migrate_tenants
```

Running this command without the call to `app_dir` results in no
migrations being run for the tenant.

See related code from Ecto that builds the migration path:
https://github.com/elixir-ecto/ecto/blob/97d75cef7f665f268a371ef56ea444483b819a5a/lib/mix/ecto.ex#L148-L150
