### PR TITLE
Update changelog to include `Apartmentex.migrate_tenant`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,15 @@ complete changelog, see the git history for each version via the version links.
 
 [hex package page]: https://hex.pm/packages/apartmentex
 
-## [Since 0.1.0]
+## [Since 0.2.0]
+
+### Changed
+
+- `Apartmentex.migrate_tenant` function added to migrate a single tenant up or down.
+
+[Since 0.2.0]: https://github.com/Dania02525/apartmentex/compare/v0.2.0...master
+
+## [0.2.0]
 
 ### Changed
 
@@ -15,4 +23,4 @@ complete changelog, see the git history for each version via the version links.
   migrations now
 - Now supports (and requires) Ecto 2.0.x
 
-[Since 0.1.0]: https://github.com/Dania02525/apartmentex/compare/v0.1.0...master
+[0.2.0]: https://github.com/Dania02525/apartmentex/compare/v0.1.0...v0.2.0


### PR DESCRIPTION
For the compare links to work, you'd have to create a couple tags that point to the commits for the releases:
- v0.1.0
- v0.2.0

https://git-scm.com/book/en/v2/Git-Basics-Tagging

It probably makes sense to release the next version to include the new migration function as well 😄 

Thanks for being so responsive on issues and PRs!
