### PR TITLE
allow postgrex 0.12

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -39,7 +39,7 @@ defmodule Apartmentex.Mixfile do
     [
       {:ecto, "~> 2.0.2"},
       {:mariaex, "~> 0.7.7", optional: true},
-      {:postgrex, "~> 0.11.0", optional: true}
+      {:postgrex, ">= 0.11.0", optional: true}
     ]
   end
 


### PR DESCRIPTION
Since postgrex has reached 0.12, thought I'd stop by and allow both 0.11 and 0.12.
