### PR TITLE
Quote schema when dropping

### DIFF
--- a/lib/apartmentex/tenant_actions.ex
+++ b/lib/apartmentex/tenant_actions.ex
@@ -42,7 +42,7 @@ defmodule Apartmentex.TenantActions do
   def drop_tenant(repo, tenant) do
     prefix = build_prefix(tenant)
     case repo.__adapter__ do
-      Ecto.Adapters.Postgres -> Ecto.Adapters.SQL.query(repo, "DROP SCHEMA #{prefix} CASCADE", [])
+      Ecto.Adapters.Postgres -> Ecto.Adapters.SQL.query(repo, "DROP SCHEMA \"#{prefix}\" CASCADE", [])
       Ecto.Adapters.MySQL -> Ecto.Adapters.SQL.query(repo, "DROP DATABASE #{prefix}", [])
     end
   end

--- a/lib/apartmentex/tenant_actions.ex
+++ b/lib/apartmentex/tenant_actions.ex
@@ -2,6 +2,10 @@ defmodule Apartmentex.TenantActions do
   import Apartmentex.MigrationsPathBuilder
   import Apartmentex.PrefixBuilder
 
+  alias Ecto.Adapters.SQL
+  alias Ecto.Adapters.Postgres
+  alias Ecto.Adapters.MySQL
+
   @doc """
   Apply migrations to a tenant with given strategy, in given direction.
 
@@ -34,16 +38,16 @@ defmodule Apartmentex.TenantActions do
   def create_schema(repo, tenant) do
     prefix = build_prefix(tenant)
     case repo.__adapter__ do
-      Ecto.Adapters.Postgres -> Ecto.Adapters.SQL.query(repo, "CREATE SCHEMA \"#{prefix}\"", [])
-      Ecto.Adapters.MySQL -> Ecto.Adapters.SQL.query(repo, "CREATE DATABASE #{prefix}", [])
+      Postgres -> SQL.query(repo, "CREATE SCHEMA \"#{prefix}\"", [])
+      MySQL    -> SQL.query(repo, "CREATE DATABASE #{prefix}", [])
     end
   end
 
   def drop_tenant(repo, tenant) do
     prefix = build_prefix(tenant)
     case repo.__adapter__ do
-      Ecto.Adapters.Postgres -> Ecto.Adapters.SQL.query(repo, "DROP SCHEMA \"#{prefix}\" CASCADE", [])
-      Ecto.Adapters.MySQL -> Ecto.Adapters.SQL.query(repo, "DROP DATABASE #{prefix}", [])
+      Postgres -> SQL.query(repo, "DROP SCHEMA \"#{prefix}\" CASCADE", [])
+      MySQL    -> SQL.query(repo, "DROP DATABASE #{prefix}", [])
     end
   end
 


### PR DESCRIPTION
I've done two pieces of work in this PR. When dropping a schema which may contain dash characters, I was getting this:

``` ex
begin []
DROP SCHEMA tenant_super-mario CASCADE []
[debug] QUERY OK db=0.4ms
commit []
{:ok,
 {:error,
  %Postgrex.Error{connection_id: 3609, message: nil,
   postgres: %{code: :syntax_error, file: "scan.l", line: "1053",
     message: "syntax error at or near \"-\"", pg_code: "42601", position: "25",
     routine: "scanner_yyerror", severity: "ERROR"}}}}
```

I went to work and added the quoting. I also noticed the lines were getting kinda long. I added some `alias`s to ease up on the nested module calls.
