### PR TITLE
Bump elixir 1.4.2

### DIFF
--- a/lib/apartmentex.ex
+++ b/lib/apartmentex.ex
@@ -158,7 +158,7 @@ defmodule Apartmentex do
 
   defp add_prefix_to_query(queryable, tenant) do
     queryable
-    |> Ecto.Queryable.to_query
+    |> Ecto.Queryable.to_query()
     |> Map.put(:prefix, build_prefix(tenant))
   end
 end

--- a/lib/apartmentex/prefix_builder.ex
+++ b/lib/apartmentex/prefix_builder.ex
@@ -1,20 +1,12 @@
 defmodule Apartmentex.PrefixBuilder do
   @schema_prefix Application.get_env(:apartmentex, :schema_prefix) || "tenant_"
 
-  def build_prefix(tenant) when is_integer(tenant) do
-    @schema_prefix <> Integer.to_string(tenant)
-  end
-
-  def build_prefix(tenant) when is_binary(tenant) do
-    @schema_prefix <> tenant
-  end
-
+  def build_prefix(tenant) when is_integer(tenant), do: @schema_prefix <> Integer.to_string(tenant)
+  def build_prefix(tenant) when is_binary(tenant), do: @schema_prefix <> tenant
   def build_prefix(tenant) do
     cond do
-      is_binary(tenant.id) ->
-        @schema_prefix <> tenant.id
-      is_integer(tenant.id) ->
-        @schema_prefix <> Integer.to_string(tenant.id)
+      is_binary(tenant.id) -> build_prefix(tenant.id)
+      is_integer(tenant.id) -> build_prefix(tenant.id)
     end
   end
 end

--- a/lib/mix/tasks/apartmentex.gen.migration.ex
+++ b/lib/mix/tasks/apartmentex.gen.migration.ex
@@ -41,7 +41,7 @@ defmodule Mix.Tasks.Apartmentex.Gen.Migration do
       case OptionParser.parse(args, switches: @switches) do
         {opts, [name], _} ->
           ensure_repo(repo, args)
-          path = Path.relative_to(tenant_migrations_path(repo), Mix.Project.app_path)
+          path = Path.relative_to(tenant_migrations_path(repo), Mix.Project.app_path())
           file = Path.join(path, "#{timestamp()}_#{underscore(name)}.exs")
           create_directory path
 

--- a/mix.exs
+++ b/mix.exs
@@ -15,7 +15,7 @@ defmodule Apartmentex.Mixfile do
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env == :prod,
       elixirc_paths: elixirc_paths(Mix.env),
-      deps: deps
+      deps: deps()
     ]
   end
 
@@ -43,7 +43,7 @@ defmodule Apartmentex.Mixfile do
     ]
   end
 
-  defp elixirc_paths(:test), do: elixirc_paths ++ ["test/support"]
-  defp elixirc_paths(_), do: elixirc_paths
+  defp elixirc_paths(:test), do: elixirc_paths() ++ ["test/support"]
+  defp elixirc_paths(_), do: elixirc_paths()
   defp elixirc_paths, do: ["lib"]
 end

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Apartmentex.Mixfile do
     [
       app: :apartmentex,
       version: "0.2.2",
-      elixir: "~> 1.2-dev",
+      elixir: "~> 1.4",
       description: "SaaS Library for Ecto applications using Postgres or Mysql",
       package: [
         links: %{"Github" => "https://github.com/Dania02525/apartmentex"},

--- a/test/apartmentex/tenant_actions_test.exs
+++ b/test/apartmentex/tenant_actions_test.exs
@@ -5,7 +5,6 @@ defmodule Apartmentex.TenantActionsTest do
   alias Apartmentex.TestPostgresRepo
 
   @migration_version 20160711125401
-  @wrong_migration_version 20160711125402
   @repo TestPostgresRepo
   @tenant_id 2
 
@@ -14,7 +13,7 @@ defmodule Apartmentex.TenantActionsTest do
   end
 
   test ".migrate_tenant/4 migrates the tenant forward by default" do
-    create_tenant_schema
+    create_tenant_schema()
 
     assert_creates_notes_table fn ->
       {status, prefix, versions} = Apartmentex.migrate_tenant(@repo, @tenant_id)
@@ -26,7 +25,7 @@ defmodule Apartmentex.TenantActionsTest do
   end
 
   test ".migrate_tenant/4 returns an error tuple when it fails" do
-    create_and_migrate_tenant
+    create_and_migrate_tenant()
 
     force_migration_failure fn(expected_postgres_error) ->
       {status, prefix, error_message} = Apartmentex.migrate_tenant(@repo, @tenant_id)
@@ -38,7 +37,7 @@ defmodule Apartmentex.TenantActionsTest do
   end
 
   test ".migrate_tenant/4 can rollback and return metadata" do
-    create_and_migrate_tenant
+    create_and_migrate_tenant()
 
     assert_drops_notes_table fn ->
       {status, prefix, versions} =
@@ -51,7 +50,7 @@ defmodule Apartmentex.TenantActionsTest do
   end
 
   test ".migrate_tenant/4 returns a tuple when it fails to rollback" do
-    create_and_migrate_tenant
+    create_and_migrate_tenant()
 
     force_rollback_failure fn(expected_postgres_error) ->
       {status, prefix, error_message} =
@@ -64,25 +63,25 @@ defmodule Apartmentex.TenantActionsTest do
   end
 
   defp assert_creates_notes_table(fun) do
-    assert_notes_table_is_dropped
+    assert_notes_table_is_dropped()
     fun.()
-    assert_notes_table_is_present
+    assert_notes_table_is_present()
   end
 
   defp assert_drops_notes_table(fun) do
-    assert_notes_table_is_present
+    assert_notes_table_is_present()
     fun.()
-    assert_notes_table_is_dropped
+    assert_notes_table_is_dropped()
   end
 
   defp assert_notes_table_is_dropped do
     assert_raise Postgrex.Error, fn ->
-      find_tenant_notes
+      find_tenant_notes()
     end
   end
 
   defp assert_notes_table_is_present do
-    assert find_tenant_notes == []
+    assert find_tenant_notes() == []
   end
 
   defp create_and_migrate_tenant do


### PR DESCRIPTION
Hey @Dania02525,

I've been going through some packages that are handing me warnings for Elixir 1.4. It appears they now handout warnings when:

1. You don't have a `()` at the end of a function with no args.
2. When you aren't using an attribute.

I've gone and "fixed" those. I bumped the elixir version to 1.4 in the mix file.

While I was going through the code, I also found a chance for some code to get refactored :D; primarily with the prefixing building.