### PR TITLE
Defer the resolution of schema_prefix until later when the Applicatio…

### DIFF
--- a/lib/apartmentex/prefix_builder.ex
+++ b/lib/apartmentex/prefix_builder.ex
@@ -1,8 +1,11 @@
 defmodule Apartmentex.PrefixBuilder do
-  @schema_prefix Application.get_env(:apartmentex, :schema_prefix) || "tenant_"
 
-  def build_prefix(tenant) when is_integer(tenant), do: @schema_prefix <> Integer.to_string(tenant)
-  def build_prefix(tenant) when is_binary(tenant), do: @schema_prefix <> tenant
+  def schema_prefix() do
+    Application.get_env(:apartmentex, :schema_prefix) || "tenant_"
+  end
+
+  def build_prefix(tenant) when is_integer(tenant), do: schema_prefix() <> Integer.to_string(tenant)
+  def build_prefix(tenant) when is_binary(tenant), do: schema_prefix() <> tenant
   def build_prefix(tenant) do
     cond do
       is_binary(tenant.id) -> build_prefix(tenant.id)


### PR DESCRIPTION
…n env is available

Hi @Dania02525 i was experiencing an issue similar to #37 where my configuration was getting ignored.

While things were behaving normally in dev and test, the resolution of the schema_prefix broke down for prod.

Apartmentex was getting compiled with the default "tenant_" because the application environment was not available at that stage of the build chain (docker cache layers & distillery).

Unless you are performing a significant number of tenancy-related operations, this should not constitute a serious performance hit.

Thanks!