### PR TITLE
Add mongodb adapter stubs.

### DIFF
--- a/lib/apartmentex/tenant_actions.ex
+++ b/lib/apartmentex/tenant_actions.ex
@@ -40,6 +40,7 @@ defmodule Apartmentex.TenantActions do
     case repo.__adapter__ do
       Postgres -> SQL.query(repo, "CREATE SCHEMA \"#{prefix}\"", [])
       MySQL    -> SQL.query(repo, "CREATE DATABASE #{prefix}", [])
+      Mongo.Ecto -> nil
     end
   end
 
@@ -48,6 +49,7 @@ defmodule Apartmentex.TenantActions do
     case repo.__adapter__ do
       Postgres -> SQL.query(repo, "DROP SCHEMA \"#{prefix}\" CASCADE", [])
       MySQL    -> SQL.query(repo, "DROP DATABASE #{prefix}", [])
+      Mongo.Ecto -> Mongo.Ecto.command(repo, [dropDatabase: 1], [database: prefix])
     end
   end
 


### PR DESCRIPTION
This allows us to synthetically "create" mongodb tenant dbs, unblocking the index migrations.

In practice this is a no-op for create. Drop needs to plug into Mongo.Ecto functionality
relying on the more recent database switching functionality (ecto-2.1 branch)